### PR TITLE
Updating Test + Pass Extend Client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 VENV_NAME ?= venv
 PIP ?= pip
-PYTHON ?= python3.11
+PYTHON ?= python3.12
 ENV ?= stage
 
 venv: $(VENV_NAME)/bin/activate
 
 $(VENV_NAME)/bin/activate: pyproject.toml
 	@test -d $(VENV_NAME) || $(PYTHON) -m venv $(VENV_NAME)
-	$(VENV_NAME)/bin/python -m pip install -e .
+	$(VENV_NAME)/bin/python -m pip install -e ".[dev]"
 	@touch $(VENV_NAME)/bin/activate
 
 test: venv
-	$(VENV_NAME)/bin/python -m unittest discover tests
+	$(VENV_NAME)/bin/pytest tests
 
 build: venv
 	cp LICENSE LICENSE.bak

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ from extend_ai_toolkit.openai.toolkit import ExtendOpenAIToolkit
 from extend_ai_toolkit.shared import Configuration, Scope, Product, Actions
 
 # Initialize the OpenAI toolkit
-extend_openai_toolkit = ExtendOpenAIToolkit(
+extend_openai_toolkit = ExtendOpenAIToolkit.default_instance(
     api_key=os.environ.get("EXTEND_API_KEY"),
     api_secret=os.environ.get("EXTEND_API_SECRET"),
     configuration=Configuration(
@@ -178,7 +178,7 @@ from extend_ai_toolkit.langchain.toolkit import ExtendLangChainToolkit
 from extend_ai_toolkit.shared import Configuration, Scope, Product, Actions
 
 # Initialize the LangChain toolkit
-extend_langchain_toolkit = ExtendLangChainToolkit(
+extend_langchain_toolkit = ExtendLangChainToolkit.default_instance(
     api_key=os.environ.get("EXTEND_API_KEY"),
     api_secret=os.environ.get("EXTEND_API_SECRET"),
     configuration=Configuration(
@@ -208,7 +208,7 @@ from extend_ai_toolkit.crewai.toolkit import ExtendCrewAIToolkit
 from extend_ai_toolkit.shared import Configuration, Scope, Product, Actions
 
 # Initialize the CrewAI toolkit
-toolkit = ExtendCrewAIToolkit(
+toolkit = ExtendCrewAIToolkit.default_instance(
     api_key=os.environ.get("EXTEND_API_KEY"),
     api_secret=os.environ.get("EXTEND_API_SECRET"),
     configuration=Configuration(

--- a/extend_ai_toolkit/crewai/toolkit.py
+++ b/extend_ai_toolkit/crewai/toolkit.py
@@ -16,16 +16,21 @@ class ExtendCrewAIToolkit(AgentToolkit[BaseTool]):
 
     def __init__(
         self,
-        api_key: str,
-        api_secret: str,
+        extend_api: ExtendAPI,
         configuration: Optional[Configuration] = None
     ):
         super().__init__(
-            api_key=api_key,
-            api_secret=api_secret,
+            extend_api=extend_api,
             configuration=configuration
         )
         self._llm = None
+        
+    @classmethod
+    def default_instance(cls, api_key: str, api_secret: str, configuration: Configuration) -> "ExtendCrewAIToolkit":
+        return cls(
+            extend_api=ExtendAPI.default_instance(api_key, api_secret),
+            configuration=configuration
+        )
 
     def configure_llm(
         self,

--- a/extend_ai_toolkit/examples/crewai-agent.py
+++ b/extend_ai_toolkit/examples/crewai-agent.py
@@ -44,7 +44,7 @@ async def main():
         api_key, api_secret = validate_env_vars()
         
         # Initialize the CrewAI toolkit
-        toolkit = ExtendCrewAIToolkit(
+        toolkit = ExtendCrewAIToolkit.default_instance(
             api_key=api_key,
             api_secret=api_secret,
             configuration=Configuration(

--- a/extend_ai_toolkit/examples/langchain-react-agent.py
+++ b/extend_ai_toolkit/examples/langchain-react-agent.py
@@ -24,7 +24,7 @@ llm = ChatOpenAI(
     model="gpt-4o",
 )
 
-extend_langchain_toolkit = ExtendLangChainToolkit(
+extend_langchain_toolkit = ExtendLangChainToolkit.default_instance(
     api_key,
     api_secret,
     Configuration(

--- a/extend_ai_toolkit/examples/openai-agent.py
+++ b/extend_ai_toolkit/examples/openai-agent.py
@@ -12,7 +12,7 @@ api_key = os.environ.get("EXTEND_API_KEY")
 api_secret = os.environ.get("EXTEND_API_SECRET")
 
 async def main():
-    extend_openai_toolkit = ExtendOpenAIToolkit(
+    extend_openai_toolkit = ExtendOpenAIToolkit.default_instance(
         api_key,
         api_secret,
         Configuration(

--- a/extend_ai_toolkit/langchain/toolkit.py
+++ b/extend_ai_toolkit/langchain/toolkit.py
@@ -13,14 +13,19 @@ class ExtendLangChainToolkit(AgentToolkit[ExtendTool]):
 
     def __init__(
             self,
-            api_key: str,
-            api_secret: str,
+            extend_api: ExtendAPI,
             configuration: Optional[Configuration]
     ):
         super().__init__(
-            api_key=api_key,
-            api_secret=api_secret,
+            extend_api=extend_api,
             configuration=configuration or Configuration.all_tools()
+        )
+        
+    @classmethod
+    def default_instance(cls, api_key: str, api_secret: str, configuration: Configuration) -> "ExtendLangChainToolkit":
+        return cls(
+            extend_api=ExtendAPI.default_instance(api_key, api_secret),
+            configuration=configuration
         )
 
     def tool_for_agent(self, api: ExtendAPI, tool: Tool) -> ExtendTool:

--- a/extend_ai_toolkit/modelcontextprotocol/main.py
+++ b/extend_ai_toolkit/modelcontextprotocol/main.py
@@ -15,7 +15,7 @@ def build_server():
     selected_tools = options.tools
     configuration = Configuration.from_tool_str(selected_tools)
 
-    return ExtendMCPServer(
+    return ExtendMCPServer.default_instance(
         api_key=options.api_key,
         api_secret=options.api_secret,
         configuration=configuration

--- a/extend_ai_toolkit/modelcontextprotocol/main_sse.py
+++ b/extend_ai_toolkit/modelcontextprotocol/main_sse.py
@@ -47,7 +47,7 @@ def build_server():
     selected_tools = options.tools
     configuration = Configuration.from_tool_str(selected_tools)
 
-    return ExtendMCPServer(
+    return ExtendMCPServer.default_instance(
         api_key=options.api_key,
         api_secret=options.api_secret,
         configuration=configuration

--- a/extend_ai_toolkit/modelcontextprotocol/server.py
+++ b/extend_ai_toolkit/modelcontextprotocol/server.py
@@ -17,16 +17,13 @@ logger.setLevel(logging.INFO)
 
 
 class ExtendMCPServer(FastMCP):
-    def __init__(self, api_key: str, api_secret: str, configuration: Configuration):
+    def __init__(self, extend_api: ExtendAPI, configuration: Configuration):
         super().__init__(
             name="Extend MCP Server",
             version=_version
         )
 
-        self._extend = ExtendAPI(
-            api_key=api_key,
-            api_secret=api_secret
-        )
+        self._extend = extend_api
 
         for tool in configuration.allowed_tools(tools):
             fn: Any = None
@@ -81,6 +78,10 @@ class ExtendMCPServer(FastMCP):
                 tool.name,
                 tool.description
             )
+            
+    @classmethod
+    def default_instance(cls, api_key: str, api_secret: str, configuration: Configuration):
+        return cls(extend_api=ExtendAPI.default_instance(api_key, api_secret), configuration=configuration)
 
     def _handle_tool_request(self, tool: Tool, fn: AnyFunction):
         async def resource_handler(*args, **kwargs):

--- a/extend_ai_toolkit/openai/toolkit.py
+++ b/extend_ai_toolkit/openai/toolkit.py
@@ -15,14 +15,19 @@ class ExtendOpenAIToolkit(AgentToolkit[FunctionTool]):
 
     def __init__(
             self,
-            api_key: str,
-            api_secret: str,
+            extend_api: ExtendAPI,
             configuration: Optional[Configuration]
     ):
         super().__init__(
-            api_key=api_key,
-            api_secret=api_secret,
+            extend_api=extend_api,
             configuration=configuration or Configuration.all_tools()
+        )
+
+    @classmethod
+    def default_instance(cls, api_key: str, api_secret: str, configuration: Configuration) -> "ExtendOpenAIToolkit":
+        return cls(
+            extend_api=ExtendAPI.default_instance(api_key, api_secret),
+            configuration=configuration
         )
 
     def tool_for_agent(self, api: ExtendAPI, tool: Tool) -> FunctionTool:

--- a/extend_ai_toolkit/shared/agent_toolkit.py
+++ b/extend_ai_toolkit/shared/agent_toolkit.py
@@ -16,22 +16,23 @@ class AgentToolkit(Generic[ToolType]):
 
     def __init__(
             self,
-            api_key: str,
-            api_secret: str,
+            extend_api: ExtendAPI,
             configuration: Configuration,
     ):
         super().__init__()
-
-        extend_api = ExtendAPI(
-            api_key=api_key,
-            api_secret=api_secret
-        )
 
         self._tools = [
             self.tool_for_agent(extend_api, tool)
             for tool in configuration.allowed_tools(tools)
         ]
 
+    @classmethod
+    def default_instance(cls, api_key: str, api_secret: str, configuration: Configuration) -> "AgentToolkit":
+        return cls(
+            extend_api=ExtendAPI.default_instance(api_key, api_secret),
+            configuration=configuration
+        )
+    
     @abstractmethod
     def tool_for_agent(self, api: ExtendAPI, tool: Tool) -> ToolType:
         raise NotImplementedError("Subclasses must implement tool_for_agent()")

--- a/extend_ai_toolkit/shared/api.py
+++ b/extend_ai_toolkit/shared/api.py
@@ -15,13 +15,18 @@ class ExtendAPI:
 
     def __init__(
             self,
-            api_key: str,
-            api_secret: str,
+            extend: ExtendClient,
     ):
 
-        self.extend = ExtendClient(
-            api_key=api_key,
-            api_secret=api_secret
+        self.extend = extend
+    
+    @classmethod
+    def default_instance(cls, api_key: str, api_secret: str) -> "ExtendAPI":
+        return cls(
+            extend=ExtendClient(
+                api_key=api_key,
+                api_secret=api_secret
+            )
         )
 
     async def run(self, tool: str, *args, **kwargs) -> str:

--- a/extend_ai_toolkit/tests/test_crewai_toolkit.py
+++ b/extend_ai_toolkit/tests/test_crewai_toolkit.py
@@ -28,7 +28,7 @@ def mock_extend_api():
     with patch('extend_ai_toolkit.shared.agent_toolkit.ExtendAPI') as mock_api_class:
         mock_api_instance = Mock(spec=ExtendAPI)
         mock_api_instance.run = AsyncMock()
-        mock_api_class.return_value = mock_api_instance
+        mock_api_class.default_instance.return_value = mock_api_instance
         yield mock_api_class, mock_api_instance
 
 
@@ -65,23 +65,13 @@ def mock_configuration():
 @pytest.fixture
 def toolkit(mock_extend_api, mock_configuration):
     """Fixture that creates an ExtendCrewAIToolkit instance with mocks"""
-    mock_api_class, mock_api_instance = mock_extend_api
+    _, mock_api_instance = mock_extend_api
     toolkit = ExtendCrewAIToolkit(
-        api_key="test_api_key",
-        api_secret="test_api_secret",
+        extend_api=mock_api_instance,
         configuration=mock_configuration
     )
+    
     return toolkit
-
-
-def test_init_creates_extend_api(toolkit, mock_extend_api):
-    """Test that ExtendAPI is initialized with correct credentials"""
-    mock_api_class, _ = mock_extend_api
-    mock_api_class.assert_called_once_with(
-        api_key="test_api_key",
-        api_secret="test_api_secret"
-    )
-
 
 def test_get_tools_returns_correct_tools(toolkit, mock_configuration):
     """Test that get_tools returns the correct set of tools"""

--- a/extend_ai_toolkit/tests/test_langchain_toolkit.py
+++ b/extend_ai_toolkit/tests/test_langchain_toolkit.py
@@ -25,7 +25,7 @@ def mock_extend_api():
     with patch('extend_ai_toolkit.shared.agent_toolkit.ExtendAPI') as mock_api_class:
         mock_api_instance = Mock(spec=ExtendAPI)
         mock_api_instance.run = AsyncMock()
-        mock_api_class.return_value = mock_api_instance
+        mock_api_class.default_instance.return_value = mock_api_instance
         yield mock_api_class, mock_api_instance
 
 
@@ -63,21 +63,10 @@ def toolkit(mock_extend_api, mock_configuration):
     """Fixture that creates an ExtendLangChainToolkit instance with mocks"""
     mock_api_class, mock_api_instance = mock_extend_api
     toolkit = ExtendLangChainToolkit(
-        api_key="test_api_key",
-        api_secret="test_api_secret",
+        extend_api=mock_api_instance,
         configuration=mock_configuration
     )
     return toolkit
-
-
-def test_init_creates_extend_api(toolkit, mock_extend_api):
-    """Test that ExtendAPI is initialized with correct credentials"""
-    mock_api_class, _ = mock_extend_api
-    mock_api_class.assert_called_once_with(
-        api_key="test_api_key",
-        api_secret="test_api_secret"
-    )
-
 
 def test_get_tools_returns_correct_tools(toolkit, mock_configuration):
     """Test that get_tools returns the correct set of tools"""
@@ -87,9 +76,9 @@ def test_get_tools_returns_correct_tools(toolkit, mock_configuration):
     assert len(tools) == 2
 
     # Verify tool details
-    assert tools[0].name == "Get Virtual Cards"
+    assert tools[0].name == "get_virtual_cards"
     assert tools[0].description == "Get all virtual cards"
-    assert tools[1].name == "Get Virtual Card Details"
+    assert tools[1].name == "get_virtual_card_detail"
     assert tools[1].description == "Get details of a virtual card"
 
 

--- a/extend_ai_toolkit/tests/test_openai_toolkit.py
+++ b/extend_ai_toolkit/tests/test_openai_toolkit.py
@@ -26,7 +26,7 @@ def mock_extend_api():
     with patch('extend_ai_toolkit.shared.agent_toolkit.ExtendAPI') as mock_api_class:
         mock_api_instance = Mock(spec=ExtendAPI)
         mock_api_instance.run = AsyncMock()
-        mock_api_class.return_value = mock_api_instance
+        mock_api_class.default_instance.return_value = mock_api_instance
         yield mock_api_class, mock_api_instance
 
 
@@ -62,22 +62,12 @@ def mock_configuration():
 @pytest.fixture
 def toolkit(mock_extend_api, mock_configuration):
     """Fixture that creates an ExtendOpenAIToolkit instance with mocks"""
-    mock_api_class, mock_api_instance = mock_extend_api
+    _, mock_api_instance = mock_extend_api
     toolkit = ExtendOpenAIToolkit(
-        api_key="test_api_key",
-        api_secret="test_api_secret",
+        extend_api=mock_api_instance,
         configuration=mock_configuration
     )
     return toolkit
-
-
-def test_init_creates_extend_api(toolkit, mock_extend_api):
-    """Test that ExtendAPI is initialized with correct credentials"""
-    mock_api_class, _ = mock_extend_api
-    mock_api_class.assert_called_once_with(
-        api_key="test_api_key",
-        api_secret="test_api_secret"
-    )
 
 
 def test_get_tools_returns_correct_tools(toolkit, mock_configuration):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "requests==2.32.3",
     "build",
     "starlette>=0.40.0,<0.46.0",
-    "openai==1.66.3",
+    "openai>=1.66.3,<2.0.0",
     "openai-agents==0.0.4",
     "paywithextend==1.1.0",
 ]
@@ -29,7 +29,7 @@ dependencies = [
 "Source Code" = "https://github.com/paywithextend/extend-ai-toolkit"
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0.1", "mypy>=1.11.1", "ruff>=0.6.1"]
+dev = ["pytest>=7.0.1", "mypy>=1.11.1", "ruff>=0.6.1", "crewai>=0.108.0", "pytest-asyncio>=0.26.0"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## What is this PR doing?

- updates toolkit test so that they run and pass + making changes based on the refactoring
- updates the api, toolkit, and implementations to expect an ExtendClient and adding a default_instance() method to use the default ExtendAPI configuration

## Why do we need these changes?

- We want to have flexibility for creating extensions from the ExtendAPI and pass those to the AI Toolkit implementations

## Additional Notes

- updates to the Make file
- update to the toml to add missing dependencies
